### PR TITLE
Script List Reorder Fix

### DIFF
--- a/addons/script_splitter/core/ui/pin/Pin.tscn
+++ b/addons/script_splitter/core/ui/pin/Pin.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=4 format=3 uid="uid://cnbyjwmktxipx"]
 
-[ext_resource type="Script" uid="uid://w8t1dg3mooti" path="res://addons/script_spliter/core/ui/pin/control.gd" id="1_2gb5h"]
-[ext_resource type="Script" uid="uid://cl3i4qjav3ikw" path="res://addons/script_spliter/core/ui/pin/root.gd" id="1_e0xng"]
-[ext_resource type="Script" uid="uid://c34ix3uq8fdae" path="res://addons/script_spliter/core/ui/pin/pin.gd" id="1_ulj15"]
+[ext_resource type="Script" uid="uid://w8t1dg3mooti" path="res://addons/script_splitter/core/ui/pin/control.gd" id="1_2gb5h"]
+[ext_resource type="Script" uid="uid://cl3i4qjav3ikw" path="res://addons/script_splitter/core/ui/pin/root.gd" id="1_e0xng"]
+[ext_resource type="Script" uid="uid://c34ix3uq8fdae" path="res://addons/script_splitter/core/ui/pin/pin.gd" id="1_ulj15"]
 
 [node name="Control" type="Control"]
 layout_mode = 3


### PR DESCRIPTION
Hi! I'm using this tool, which I think it's great, thanks! :D

I noticed that the reorder functionality of the script list panel in the left (base functionality from Godot) is somehow broken? So scripts can no longer be reordered when dragging them in that list.

I made a bit of a nasty fix by listening the signal `_script_list.gui_input` in `list.gd` and adding a function that does the script reorder. I don't 100% like it because it looks a bit ugly and probably can be fixed easily using whatever base functionality there is without overriding anything, but I did it fast and without having enough time to focus on how it actually all works. Though, if you want it, it's all yours :)

I also saw there are a couple of broken dependencies in `Pin.tscn` likely coming from a rename done some time ago, so I also fixed them :)
Thanks! :D

PS: Btw, I'd really like to see a couple of features (creating splits if dragging from this script list and also if dragging from the top tabs bar), should I add them as enhancement issues?
